### PR TITLE
Fix document content detection

### DIFF
--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -136,10 +136,11 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
       .then(doc => {
         setName(doc.name || '');
 
-        if (doc.content) {
+        if (typeof doc.content === 'string') {
           setContent(doc.content);
-          setChars(doc.content.split('').map((ch: string) => ({ ch, userId: null })));
-
+          setChars(
+            doc.content.split('').map((ch: string) => ({ ch, userId: null }))
+          );
         }
       });
 


### PR DESCRIPTION
## Summary
- handle non-string content when loading documents

## Testing
- `npm install` *(for frontend)*
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bd27145448332bbc9ccdf55ff651d