### PR TITLE
Sanitize text ops in editor

### DIFF
--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -60,7 +60,11 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
 
   const applyTextOp = (text: string, op: Operation) => {
     const insert =
-      typeof op.insertText === 'string' ? op.insertText : String(op.insertText);
+      typeof op.insertText === 'string'
+        ? op.insertText
+        : op.insertText != null
+        ? String(op.insertText)
+        : '';
     return text.slice(0, op.index) + insert + text.slice(op.index + op.deleteCount);
   };
 
@@ -68,7 +72,11 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
     const before = arr.slice(0, op.index);
     const after = arr.slice(op.index + op.deleteCount);
     const text =
-      typeof op.insertText === 'string' ? op.insertText : String(op.insertText);
+      typeof op.insertText === 'string'
+        ? op.insertText
+        : op.insertText != null
+        ? String(op.insertText)
+        : '';
     const inserted = text.split('').map(ch => ({ ch, userId: op.userId }));
     return [...before, ...inserted, ...after];
   };
@@ -179,7 +187,11 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
       while (j < chars.length && chars[j].userId === uid) j++;
       const text = chars
         .slice(i, j)
-        .map(c => escapeHtml(String(c.ch)))
+        .map(c =>
+          escapeHtml(
+            typeof c.ch === 'string' ? c.ch : c.ch != null ? String(c.ch) : ''
+          )
+        )
         .join('');
       if (uid && showWriters) {
         html += `<span style="background-color:${getColor(uid)}77">${text}</span>`;

--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -59,17 +59,17 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
   };
 
   const applyTextOp = (text: string, op: Operation) => {
-    return (
-      text.slice(0, op.index) +
-      op.insertText +
-      text.slice(op.index + op.deleteCount)
-    );
+    const insert =
+      typeof op.insertText === 'string' ? op.insertText : String(op.insertText);
+    return text.slice(0, op.index) + insert + text.slice(op.index + op.deleteCount);
   };
 
   const applyCharOp = (arr: Char[], op: Operation) => {
     const before = arr.slice(0, op.index);
     const after = arr.slice(op.index + op.deleteCount);
-    const inserted = op.insertText.split('').map(ch => ({ ch, userId: op.userId }));
+    const text =
+      typeof op.insertText === 'string' ? op.insertText : String(op.insertText);
+    const inserted = text.split('').map(ch => ({ ch, userId: op.userId }));
     return [...before, ...inserted, ...after];
   };
 
@@ -159,7 +159,10 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
       const uid = chars[i].userId;
       let j = i;
       while (j < chars.length && chars[j].userId === uid) j++;
-      const text = chars.slice(i, j).map(c => escapeHtml(c.ch)).join('');
+      const text = chars
+        .slice(i, j)
+        .map(c => escapeHtml(String(c.ch)))
+        .join('');
       if (uid && showWriters) {
         html += `<span style="background-color:${getColor(uid)}77">${text}</span>`;
       } else {

--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -103,17 +103,27 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
 
     socket.emit('join-document', id);
 
-    socket.on('document', (data: any) => {
-      if (typeof data === 'string') {
-        setContent(data);
-        setChars(data.split('').map(ch => ({ ch, userId: null })));
-      } else if (data && typeof data.content === 'string') {
-        setContent(data.content);
-        const arr = data.content.split('').map((ch: string, i: number) => ({
+    socket.on('document', (payload: any) => {
+      let text: string | undefined;
+
+      if (typeof payload === 'string') {
+        text = payload;
+      } else if (payload && typeof payload === 'object') {
+        if (typeof payload.content === 'string') text = payload.content;
+        else if (typeof payload.data === 'string') text = payload.data;
+        else if (typeof payload.text === 'string') text = payload.text;
+      }
+
+      if (typeof text === 'string') {
+        setContent(text);
+        const arr = text.split('').map((ch: string, i: number) => ({
           ch,
-          userId: data.authors?.[i] || null,
+          userId: (payload as any)?.authors?.[i] || null,
         }));
         setChars(arr);
+      } else {
+        setContent('');
+        setChars([]);
       }
     });
 
@@ -125,13 +135,21 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
     fetchApi(`https://livedocs-gool.onrender.com/document/${id}`)
       .then(res => res.json())
       .then(doc => {
-        setName(doc.name || '');
+        const { name = '', content, data, text } = doc || {};
+        setName(name);
 
-        if (typeof doc.content === 'string') {
-          setContent(doc.content);
-          setChars(
-            doc.content.split('').map((ch: string) => ({ ch, userId: null }))
-          );
+        const initial =
+          typeof content === 'string'
+            ? content
+            : typeof data === 'string'
+            ? data
+            : typeof text === 'string'
+            ? text
+            : '';
+
+        if (initial) {
+          setContent(initial);
+          setChars(initial.split('').map((ch: string) => ({ ch, userId: null })));
         }
       });
 


### PR DESCRIPTION
## Summary
- sanitize socket data in DocumentEditor to prevent `[object Object]` insertion
- ensure overlay escapes non-string characters

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864238f01848332aa295dae1b6bcc59