### PR TITLE
Fix configuration for remote deployment

### DIFF
--- a/Front-end/src/App.tsx
+++ b/Front-end/src/App.tsx
@@ -15,7 +15,7 @@ const DocumentWrapper: React.FC = () => {
 
 function App() {
   return (
-    <Router>
+    <Router basename={process.env.PUBLIC_URL}>
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />

--- a/Front-end/src/Dashboard.tsx
+++ b/Front-end/src/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_URL } from './config';
 
 interface User {
   _id: string;
@@ -53,16 +54,16 @@ const Dashboard: React.FC = () => {
       return;
     }
     const u = JSON.parse(stored);
-    fetch(`https://livedocs-gool.onrender.com/users/${u._id}`)
+    fetch(`${API_URL}/users/${u._id}`)
       .then(res => res.json())
       .then(data => setUser(data));
-    fetch('https://livedocs-gool.onrender.com/users')
+    fetch(`${API_URL}/users`)
       .then(res => res.json())
       .then(data => setOthers(data.filter((o: OtherUser) => o._id !== u._id)));
-    fetch(`https://livedocs-gool.onrender.com/users/${u._id}/incoming-requests`)
+    fetch(`${API_URL}/users/${u._id}/incoming-requests`)
       .then(res => res.json())
       .then(setIncoming);
-    fetch(`https://livedocs-gool.onrender.com/users/${u._id}/outgoing-requests`)
+    fetch(`${API_URL}/users/${u._id}/outgoing-requests`)
       .then(res => res.json())
       .then(setOutgoing);
 
@@ -70,7 +71,7 @@ const Dashboard: React.FC = () => {
 
   const createDoc = async () => {
     if (!user) return;
-    const res = await fetch('https://livedocs-gool.onrender.com/documents', {
+    const res = await fetch(`${API_URL}/documents`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ownerId: user._id })
@@ -82,7 +83,7 @@ const Dashboard: React.FC = () => {
 
   const sendRequest = async (docId: string, permission: string) => {
     if (!user) return;
-    await fetch(`https://livedocs-gool.onrender.com/documents/${docId}/request`, {
+    await fetch(`${API_URL}/documents/${docId}/request`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ userId: user._id, permission })
@@ -91,14 +92,14 @@ const Dashboard: React.FC = () => {
   };
 
   const grantRequest = async (docId: string, requesterId: string) => {
-    await fetch(`https://livedocs-gool.onrender.com/documents/${docId}/requests/${requesterId}/grant`, {
+    await fetch(`${API_URL}/documents/${docId}/requests/${requesterId}/grant`, {
       method: 'POST'
     });
     setIncoming(prev => prev.filter(r => !(r.documentId === docId && r.requesterId === requesterId)));
   };
 
   const removeRequest = async (docId: string, requesterId: string, type: 'incoming' | 'outgoing') => {
-    await fetch(`https://livedocs-gool.onrender.com/documents/${docId}/requests/${requesterId}`, {
+    await fetch(`${API_URL}/documents/${docId}/requests/${requesterId}`, {
       method: 'DELETE'
     });
     if (type === 'incoming') {

--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { API_URL, SOCKET_URL } from './config';
 
 const fetchApi: typeof fetch =
   (typeof window !== 'undefined' && (window as any).fetch) ||
@@ -65,7 +66,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
   };
 
   useEffect(() => {
-    const socket = io('https://livedocs-gool.onrender.com');
+    const socket = io(SOCKET_URL);
     socketRef.current = socket;
 
     socket.emit('join-document', id);
@@ -88,7 +89,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
       setContent(prev => applyTextOp(prev, op));
     });
 
-    fetchApi(`https://livedocs-gool.onrender.com/document/${id}`)
+    fetchApi(`${API_URL}/document/${id}`)
       .then(res => res.json())
       .then(doc => {
         const { name = '', content, data, text } = doc || {};
@@ -122,7 +123,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
   };
 
   const saveAndExit = async () => {
-    await fetchApi(`https://livedocs-gool.onrender.com/documents/${id}`, {
+    await fetchApi(`${API_URL}/documents/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, content })

--- a/Front-end/src/Login.tsx
+++ b/Front-end/src/Login.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_URL } from './config';
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -9,7 +10,7 @@ const Login: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch('https://livedocs-gool.onrender.com/login', {
+      const res = await fetch(`${API_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })

--- a/Front-end/src/Signup.tsx
+++ b/Front-end/src/Signup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_URL } from './config';
 
 const Signup: React.FC = () => {
   const [name, setName] = useState('');
@@ -10,7 +11,7 @@ const Signup: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch('https://livedocs-gool.onrender.com/signup', {
+      const res = await fetch(`${API_URL}/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, email, password })

--- a/Front-end/src/config.ts
+++ b/Front-end/src/config.ts
@@ -1,0 +1,2 @@
+export const API_URL = process.env.REACT_APP_API_URL || 'https://livedocs-gool.onrender.com';
+export const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || API_URL;

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ npm run dev
 ```
 
 Ensure MongoDB is accessible using the connection string you provide in the `.env` file.
+
+## Frontend Configuration
+
+The React client can be pointed to a custom API and WebSocket server by setting the following environment variables when running `npm start` or building the docs:
+
+```
+REACT_APP_API_URL=<backend http base URL>
+REACT_APP_SOCKET_URL=<backend websocket URL>
+```
+
+If not provided, both default to `https://livedocs-gool.onrender.com`.


### PR DESCRIPTION
## Summary
- add configurable API and socket endpoints for the React client
- set Router basename for GitHub Pages deployments
- document the new frontend environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643b866118833286f5fd0fda106c5e