### PR TITLE
Fix realtime editor updates for collaborators

### DIFF
--- a/Back-end/server.js
+++ b/Back-end/server.js
@@ -108,8 +108,8 @@ io.on("connection", (socket) => {
       await doc.save();
       // send operation to other clients
       socket.to(id).emit("document-op", op);
-      // also send the updated full content
-      io.to(id).emit("document", newContent);
+      // send updated content only to the editor as confirmation
+      socket.emit("document", newContent);
     });
   });
 });

--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -71,6 +71,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
 
     socket.emit('join-document', id);
 
+    let initialized = false;
     socket.on('document', (payload: any) => {
       let text: string | undefined;
 
@@ -82,7 +83,10 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
         else if (typeof payload.text === 'string') text = payload.text;
       }
 
-      setContent(typeof text === 'string' ? text : '');
+      if (!initialized) {
+        setContent(typeof text === 'string' ? text : '');
+        initialized = true;
+      }
     });
 
     socket.on('document-op', (op: Operation) => {


### PR DESCRIPTION
## Summary
- send socket `document` updates only to the editing client
- ignore repeated `document` events on the front-end

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652c2d461c833290f18db639a99edc