### PR TITLE
Default dev API url

### DIFF
--- a/Back-end/server.js
+++ b/Back-end/server.js
@@ -30,9 +30,17 @@ const app = express();
 const server = http.createServer(app);
 const allowedOrigins = process.env.CORS_ORIGIN
   ? process.env.CORS_ORIGIN.split(',').map((o) => o.trim())
-  : ["https://jameel0901.github.io"];
+  : [
+      "https://jameel0901.github.io",
+      "http://localhost:3000",
+    ];
 
-const io = new Server(server, { cors: { origin: allowedOrigins } });
+const io = new Server(server, {
+  cors: {
+    origin: allowedOrigins,
+    methods: ["GET", "POST"],
+  },
+});
 connectDb();
 //Returns middleware that only parses the json data
 app.use(bodyParser.json());

--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -28,7 +28,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
   const quillRef = useRef<ReactQuill | null>(null);
 
   useEffect(() => {
-    const socket = io(SOCKET_URL);
+    const socket = io(SOCKET_URL, { transports: ['websocket'] });
     socketRef.current = socket;
 
     socket.emit('join-document', id);

--- a/Front-end/src/config.ts
+++ b/Front-end/src/config.ts
@@ -1,2 +1,7 @@
-export const API_URL = process.env.REACT_APP_API_URL || 'https://livedocs-gool.onrender.com';
+const defaultUrl =
+  typeof window !== 'undefined' && window.location.hostname === 'localhost'
+    ? 'http://localhost:5000'
+    : 'https://livedocs-gool.onrender.com';
+
+export const API_URL = process.env.REACT_APP_API_URL || defaultUrl;
 export const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || API_URL;

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Create a `.env` file inside the `Back-end` directory (the server always loads it
 ```
 PORT=5000
 ATLAS_URI=<your MongoDB connection string>
-CORS_ORIGIN=https://jameel0901.github.io
+CORS_ORIGIN=https://jameel0901.github.io,http://localhost:3000
 ```
 
 `PORT` sets the HTTP/WebSocket server port and defaults to `5000` if not specified.
 `ATLAS_URI` is required for connecting to your MongoDB database.
 `CORS_ORIGIN` sets the allowed origins for HTTP and WebSocket requests. Multiple
 origins can be separated with commas.
+The default configuration allows both the hosted demo domain and
+`http://localhost:3000` so the React dev server works without additional setup.
 
 ## Running the Application
 
@@ -38,4 +40,9 @@ REACT_APP_API_URL=<backend http base URL>
 REACT_APP_SOCKET_URL=<backend websocket URL>
 ```
 
-If not provided, both default to `https://livedocs-gool.onrender.com`.
+If these variables are omitted and the app is served from `localhost`,
+the client automatically connects to `http://localhost:5000`.
+Otherwise it falls back to `https://livedocs-gool.onrender.com`.
+
+The WebSocket server allows `GET` and `POST` methods and the frontend
+forces WebSocket transport to improve live updates when hosted.


### PR DESCRIPTION
## Summary
- detect localhost in frontend config so API defaults to `http://localhost:5000`
- document the automatic localhost fallback in the frontend setup
- allow GET/POST in socket.io CORS and force WebSocket transport in the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686683a5f8688332a8cabd060913ece1