### PR TITLE
Fix socket connection to support fallback transports

### DIFF
--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -28,7 +28,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
   const quillRef = useRef<ReactQuill | null>(null);
 
   useEffect(() => {
-    const socket = io(SOCKET_URL, { transports: ['websocket'] });
+    const socket = io(SOCKET_URL);
     socketRef.current = socket;
 
     socket.emit('join-document', id);


### PR DESCRIPTION
## Summary
- remove forced WebSocket transport so Socket.IO can fall back to polling when necessary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686697ae6b308332871e2389b65ac51b