### PR TITLE
Refactor backend URLs with central config

### DIFF
--- a/Front-end/src/Dashboard.tsx
+++ b/Front-end/src/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { API_BASE_URL } from './config';
 
 interface User {
   _id: string;
@@ -53,16 +54,16 @@ const Dashboard: React.FC = () => {
       return;
     }
     const u = JSON.parse(stored);
-    fetch(`http://localhost:5000/users/${u._id}`)
+    fetch(`${API_BASE_URL}/users/${u._id}`)
       .then(res => res.json())
       .then(data => setUser(data));
-    fetch('http://localhost:5000/users')
+    fetch(`${API_BASE_URL}/users`)
       .then(res => res.json())
       .then(data => setOthers(data.filter((o: OtherUser) => o._id !== u._id)));
-    fetch(`http://localhost:5000/users/${u._id}/incoming-requests`)
+    fetch(`${API_BASE_URL}/users/${u._id}/incoming-requests`)
       .then(res => res.json())
       .then(setIncoming);
-    fetch(`http://localhost:5000/users/${u._id}/outgoing-requests`)
+    fetch(`${API_BASE_URL}/users/${u._id}/outgoing-requests`)
       .then(res => res.json())
       .then(setOutgoing);
 
@@ -70,7 +71,7 @@ const Dashboard: React.FC = () => {
 
   const createDoc = async () => {
     if (!user) return;
-    const res = await fetch('http://localhost:5000/documents', {
+    const res = await fetch(`${API_BASE_URL}/documents`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ownerId: user._id })
@@ -82,7 +83,7 @@ const Dashboard: React.FC = () => {
 
   const sendRequest = async (docId: string, permission: string) => {
     if (!user) return;
-    await fetch(`http://localhost:5000/documents/${docId}/request`, {
+    await fetch(`${API_BASE_URL}/documents/${docId}/request`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ userId: user._id, permission })
@@ -91,14 +92,14 @@ const Dashboard: React.FC = () => {
   };
 
   const grantRequest = async (docId: string, requesterId: string) => {
-    await fetch(`http://localhost:5000/documents/${docId}/requests/${requesterId}/grant`, {
+    await fetch(`${API_BASE_URL}/documents/${docId}/requests/${requesterId}/grant`, {
       method: 'POST'
     });
     setIncoming(prev => prev.filter(r => !(r.documentId === docId && r.requesterId === requesterId)));
   };
 
   const removeRequest = async (docId: string, requesterId: string, type: 'incoming' | 'outgoing') => {
-    await fetch(`http://localhost:5000/documents/${docId}/requests/${requesterId}`, {
+    await fetch(`${API_BASE_URL}/documents/${docId}/requests/${requesterId}`, {
       method: 'DELETE'
     });
     if (type === 'incoming') {

--- a/Front-end/src/DocumentEditor.tsx
+++ b/Front-end/src/DocumentEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { API_BASE_URL, SOCKET_URL } from './config';
 
 const fetchApi: typeof fetch =
   (typeof window !== 'undefined' && (window as any).fetch) ||
@@ -14,14 +15,14 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
-    const socket = io('http://localhost:5000');
+    const socket = io(SOCKET_URL);
     socketRef.current = socket;
     socket.emit('join-document', id);
     socket.on('document', (data: string) => {
       setContent(data);
     });
 
-    fetchApi(`http://localhost:5000/document/${id}`)
+    fetchApi(`${API_BASE_URL}/document/${id}`)
       .then(res => res.json())
       .then(doc => setName(doc.name || ''));
 
@@ -38,7 +39,7 @@ const DocumentEditor: React.FC<Props> = ({ id, onExit }) => {
 
 
   const saveAndExit = async () => {
-    await fetchApi(`http://localhost:5000/documents/${id}` , {
+    await fetchApi(`${API_BASE_URL}/documents/${id}` , {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, content })

--- a/Front-end/src/Login.tsx
+++ b/Front-end/src/Login.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { API_BASE_URL } from './config';
 import { useNavigate } from 'react-router-dom';
 
 const Login: React.FC = () => {
@@ -9,7 +10,7 @@ const Login: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:5000/login', {
+      const res = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })

--- a/Front-end/src/Signup.tsx
+++ b/Front-end/src/Signup.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { API_BASE_URL } from './config';
 import { useNavigate } from 'react-router-dom';
 
 const Signup: React.FC = () => {
@@ -10,7 +11,7 @@ const Signup: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:5000/signup', {
+      const res = await fetch(`${API_BASE_URL}/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, email, password })

--- a/Front-end/src/config.ts
+++ b/Front-end/src/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL = 'https://livedocs-gool.onrender.com';
+export const SOCKET_URL = 'https://livedocs-gool.onrender.com';


### PR DESCRIPTION
## Summary
- restore build artifacts to avoid large diffs
- centralize backend URL in a new `config.ts`
- update editor, dashboard, login and signup to use the constants

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b6df710883328597e7c4ec5df7f0